### PR TITLE
dev

### DIFF
--- a/deno.jsonc
+++ b/deno.jsonc
@@ -37,12 +37,12 @@
       "description": "Quick git commit",
       "command": "git add -A && git commit",
       "dependencies": [
-        "start"
+        "format"
       ]
     },
-    "merge-dev-into-main": {
+    "pr": {
       "description": "Shortcut to create PR and merge dev branch into main",
-      "command": "git push origin dev && gh pr create && gh pr merge",
+      "command": "git push origin dev && gh pr create --fill-verbose && gh pr merge --auto --merge",
       "dependencies": [
         "gitam"
       ]

--- a/magic-postman-scripts.js
+++ b/magic-postman-scripts.js
@@ -1,4 +1,4 @@
-'use strict';
+"use strict";
 
 function guard_before_query() {
   const env_name_like = magic.guard?.env_name_like;
@@ -19,13 +19,15 @@ function guard_before_query() {
 function mapping(mapping2, source, destination, prefix = "") {
   if (!mapping2) return;
   Object.entries(mapping2).forEach(([k, mayBePath]) => {
-    const [path, options] = Array.isArray(mayBePath[0]) ? [mayBePath[0], mayBePath[1]] : [mayBePath, null];
+    const [path, options] = Array.isArray(mayBePath[0])
+      ? [mayBePath[0], mayBePath[1]]
+      : [mayBePath, null];
     let value = path.reduce((acc, p) => acc[p], source);
     console.debug(`Set ${destination}.${prefix + k} = ${value}`);
     pm[destination].set(
       prefix + k,
       value,
-      options?.type || void 0
+      options?.type || void 0,
     );
   });
 }
@@ -33,7 +35,7 @@ function mapping(mapping2, source, destination, prefix = "") {
 function test_after_response() {
   const {
     name = pm.request.name,
-    description
+    description,
   } = magic;
   name && console.info(name);
   description && console.log(description);
@@ -49,9 +51,10 @@ function test_after_response() {
       req_fbody_to_env,
       req_fbody_to_globals,
       req_fbody_to_col,
-      prefix
+      prefix,
     } = magic;
-    const actual_res_code = pm.response.code || pm.response.transport.http?.statusCode;
+    const actual_res_code = pm.response.code ||
+      pm.response.transport.http?.statusCode;
     if (!actual_res_code) {
       console.warn("Unable to get res status code... Please open the issue");
     } else if (!res_codes.includes(actual_res_code)) {

--- a/magic-postman-scripts.js
+++ b/magic-postman-scripts.js
@@ -15,9 +15,6 @@ function guard_before_query() {
     throw new Error(`Use with "${env_name_like}"-like named environment!`);
   }
 }
-if (pm.info.eventName === "beforeQuery") {
-  guard_before_query();
-}
 
 function mapping(mapping2, source, destination, prefix = "") {
   if (!mapping2) return;
@@ -25,13 +22,14 @@ function mapping(mapping2, source, destination, prefix = "") {
     const [path, options] = Array.isArray(mayBePath[0]) ? [mayBePath[0], mayBePath[1]] : [mayBePath, null];
     let value = path.reduce((acc, p) => acc[p], source);
     console.debug(`Set ${destination}.${prefix + k} = ${value}`);
-    pm[destination].set(prefix + k, value, options?.type || void 0);
+    pm[destination].set(
+      prefix + k,
+      value,
+      options?.type || void 0
+    );
   });
 }
 
-if (pm.info.eventName === "afterResponse") {
-  test_after_response();
-}
 function test_after_response() {
   const {
     name = pm.request.name,
@@ -83,4 +81,10 @@ function test_after_response() {
     mapping(req_fbody_to_col, fData, "collectionVariables", prefix);
     mapping(req_fbody_to_globals, fData, "globals", prefix);
   });
+}
+
+if (pm.info.eventName === "beforeQuery") {
+  guard_before_query();
+} else {
+  test_after_response();
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@types/chai": "^5.0.1",
         "@types/postman-collection": "^3.5.10",
         "pkgroll": "^2.11.2",
-        "typescript": "^5.7.3"
+        "typescript": "^5.8.2"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1487,9 +1487,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,6 @@
     "@types/chai": "^5.0.1",
     "@types/postman-collection": "^3.5.10",
     "pkgroll": "^2.11.2",
-    "typescript": "^5.7.3"
+    "typescript": "^5.8.2"
   }
 }

--- a/src/guard_before_query.ts
+++ b/src/guard_before_query.ts
@@ -1,4 +1,4 @@
-function guard_before_query() {
+export function guard_before_query() {
   const env_name_like = magic.guard?.env_name_like;
   const curr = pm.environment.name;
 
@@ -15,8 +15,4 @@ function guard_before_query() {
   if (!ok) {
     throw new Error(`Use with "${env_name_like}"-like named environment!`);
   }
-}
-
-if (pm.info.eventName === "beforeQuery") {
-  guard_before_query();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,8 @@
-import "./guard_before_query";
-import "./test_after_response";
+import { guard_before_query } from "./guard_before_query";
+import { test_after_response } from "./test_after_response";
+
+if (pm.info.eventName === "beforeQuery") {
+  guard_before_query();
+} else {
+  test_after_response();
+}

--- a/src/test_after_response.ts
+++ b/src/test_after_response.ts
@@ -2,11 +2,7 @@ import { mapping } from "./lib/mapping";
 import * as _types from "./types";
 _types;
 
-if (pm.info.eventName === "afterResponse") {
-  test_after_response();
-}
-
-function test_after_response() {
+export function test_after_response() {
   const {
     name = pm.request.name,
     description,


### PR DESCRIPTION
- **configure base build process**
  

- **rewrite initial version to ts-like project**
  

- **add guard feature**
  

- **refactor**
  

- **simplify json (auto res.json or res as j-data at once), refactor scripts in project**
  

- **fix aka build process**
  

- **incapsulate guard logic into magic**
  

- **fix res_codes**
  

- **alternative way to get res status code**
  

- **fix json from response as it is**
  

- **toy ci/cd refactor**
  

- **split logic into before and after query**
  So the same eval(pm.globals.get('magic'))
  can be used both in scripts
  after response and before query.
  

- **magic.name, magic.description**
  

- **auto stringify json-value during saving to pm vars**
  

- **use postman-collection types, use box solution for non-string vars**
  

- **update dependency of ts**
  

- **fix**
  

- **update deno tasks with more automated pr version**
  