### PR TITLE
dev

### DIFF
--- a/magic-postman-scripts.js
+++ b/magic-postman-scripts.js
@@ -19,15 +19,20 @@ function guard_before_query() {
 function mapping(mapping2, source, destination, prefix = "") {
   if (!mapping2) return;
   Object.entries(mapping2).forEach(([k, mayBePath]) => {
-    const [path, options] = Array.isArray(mayBePath[0])
-      ? [mayBePath[0], mayBePath[1]]
-      : [mayBePath, null];
+    const last = mayBePath.pop();
+    const path = mayBePath;
+    let is_string = false;
+    if (!last) return;
+    if (typeof last === "string") {
+      path.push(last);
+      is_string = true;
+    }
     let value = path.reduce((acc, p) => acc[p], source);
     console.debug(`Set ${destination}.${prefix + k} = ${value}`);
     pm[destination].set(
       prefix + k,
       value,
-      options?.type || void 0,
+      is_string ? void 0 : last.type,
     );
   });
 }

--- a/src/lib/ctx-managment.ts
+++ b/src/lib/ctx-managment.ts
@@ -1,0 +1,8 @@
+export function ctx_management(destination: VarScopeName) {
+  const prev = pm[destination].get<object>(destination);
+  const fresh = magic[`ctx_${destination}`];
+
+  /**
+   * TODO
+   */
+}

--- a/src/lib/mapping.ts
+++ b/src/lib/mapping.ts
@@ -1,21 +1,34 @@
 export function mapping(
   mapping: Mapping | undefined,
-  source: any,
+  source: Record<string, any>,
   destination: VarScopeName,
   prefix = "",
 ) {
   if (!mapping) return;
   Object.entries(mapping).forEach(([k, mayBePath]) => {
-    const [path, options] = Array.isArray(mayBePath[0])
-      ? [mayBePath[0], mayBePath[1]]
-      : [mayBePath as string[], null];
+    /// possibly object with data-type clarification
+    const last = mayBePath.pop();
+    const path = mayBePath as string[];
+    let is_string = false;
+    /// nothing to do...
+    if (!last) return;
+    /// all items are strings - so it was only path
+    if (typeof last === "string") {
+      path.push(last);
+      is_string = true;
+    } else {
+      /// otherwise <last> is the type clarification
+    }
+
+    /// move into object/array key/index by key/index
     let value = path.reduce((acc, p) => acc[p], source);
+
     console.debug(`Set ${destination}.${prefix + k} = ${value}`);
 
     pm[destination].set(
       prefix + k,
       value,
-      (options as null | MayBeOptions)?.type || undefined,
+      is_string ? undefined : (last as { type: VarConvertType }).type,
     );
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,12 +11,12 @@ declare global {
   type MayBeOptions = { type: VarConvertType };
   type VarScopeName = "environment" | "collectionVariables" | "globals";
   type VarScope = Record<VarScopeName, {
-    get: (name: string) => string | null;
+    get: <T = string>(name: string) => T | null;
     set: (name: string, value: any, type?: VarConvertType) => void;
   }>;
   /// === custom global variables ===
   const res_code: number;
-  const magic: {
+  const magic: Record<`ctx_${VarScopeName}`, {}> & {
     /// general info
     name?: string;
     description?: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,13 +1,23 @@
 import { expect } from "chai";
 import { Response } from "postman-collection";
 
+export const VAR_CONVERT_TYPE_all = Object.keys(
+  {
+    string: null,
+    number: null,
+    boolean: null,
+    object: null,
+    array: null,
+  } satisfies Record<VarConvertType, null>,
+) as readonly VarConvertType[];
+
 declare global {
   type VarConvertType = "string" | "boolean" | "number" | "object" | "array";
   type Mapping = Record<
     string,
     MayBePath
   >;
-  type MayBePath = string[] | [string[], { type: VarConvertType }];
+  type MayBePath = string[] | [...string[], { type: VarConvertType }];
   type MayBeOptions = { type: VarConvertType };
   type VarScopeName = "environment" | "collectionVariables" | "globals";
   type VarScope = Record<VarScopeName, {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,19 +17,25 @@ declare global {
   /// === custom global variables ===
   const res_code: number;
   const magic: {
+    /// general info
     name?: string;
     description?: string;
+    /// common testing over res.status codes
     res_codes: number[];
+    /// === mapping res data to postman variables ===
     res_jbody_to_env?: Mapping;
     res_jbody_to_col?: Mapping;
     res_jbody_to_globals?: Mapping;
+    /// === mapping req data to postman variables ===
     req_jbody_to_env?: Mapping;
     req_jbody_to_col?: Mapping;
     req_jbody_to_globals?: Mapping;
     req_fbody_to_env?: Mapping;
     req_fbody_to_globals?: Mapping;
     req_fbody_to_col?: Mapping;
+    /// === use extra-prefix for variables to avoid conflicts ===
     prefix?: string;
+    /// === possible prevention of running request ===
     guard?: {
       env_name_like?: RegExp | RegExp[];
     };


### PR DESCRIPTION
- **configure base build process**
  

- **rewrite initial version to ts-like project**
  

- **add guard feature**
  

- **refactor**
  

- **simplify json (auto res.json or res as j-data at once), refactor scripts in project**
  

- **fix aka build process**
  

- **incapsulate guard logic into magic**
  

- **fix res_codes**
  

- **alternative way to get res status code**
  

- **fix json from response as it is**
  

- **toy ci/cd refactor**
  

- **split logic into before and after query**
  So the same eval(pm.globals.get('magic'))
  can be used both in scripts
  after response and before query.
  

- **magic.name, magic.description**
  

- **auto stringify json-value during saving to pm vars**
  

- **use postman-collection types, use box solution for non-string vars**
  

- **update dependency of ts**
  

- **fix**
  

- **update deno tasks with more automated pr version**
  

- **update aka-docs comments in types**
  