### PR TITLE
dev

### DIFF
--- a/src/helpers/deep_merge.ts
+++ b/src/helpers/deep_merge.ts
@@ -1,0 +1,11 @@
+export function deep_merge<T>(a: T, b: T): T {
+  const _a: any = a;
+  const _b: any = b;
+  if (Array.isArray(_a) && Array.isArray(_b)) return [..._a, ..._b] as T;
+  if (_a && _b && typeof _a === "object" && typeof _b === "object") {
+    return Object.fromEntries(
+      new Set([...Object.keys(_a), ...Object.keys(_b)] as any[]).values(),
+    ).map((key: any) => [key, deep_merge(_a[key], _b[key])]) as T;
+  }
+  return _b ?? _a;
+}

--- a/src/lib/mapping.ts
+++ b/src/lib/mapping.ts
@@ -1,3 +1,5 @@
+import { deep_merge } from "../helpers/deep_merge";
+
 export function mapping(
   mapping: Mapping | undefined,
   source: Record<string, any>,
@@ -6,29 +8,67 @@ export function mapping(
 ) {
   if (!mapping) return;
   Object.entries(mapping).forEach(([k, mayBePath]) => {
-    /// possibly object with data-type clarification
-    const last = mayBePath.pop();
+    const last = mayBePath.pop(); /// possibly object with data-type clarification
     const path = mayBePath as string[];
-    let is_string = false;
-    /// nothing to do...
-    if (!last) return;
-    /// all items are strings - so it was only path
+    if (!last) {
+      /// nothing to do...
+      return;
+    }
+    const options: Required<MayBeOptions> = {
+      type: "string",
+      strategy: "replace",
+    };
     if (typeof last === "string") {
+      /// all items are strings - so it was only path
       path.push(last);
-      is_string = true;
     } else {
       /// otherwise <last> is the type clarification
+      last.type && (options.type = last.type);
+      last.strategy && (options.strategy = last.strategy);
     }
 
-    /// move into object/array key/index by key/index
-    let value = path.reduce((acc, p) => acc[p], source);
+    let value: any = path.reduce((acc, p) => acc[p], source); /// move into object/array key/index by key/index
+
+    const key = prefix + k;
+    const prev = pm[destination].get<any>(key);
+
+    if (prev && options.strategy === "propose") {
+      /// for <propose> strategy we do not touch existed value and ignore new
+      value = prev;
+      console.debug(
+        "The old value will be used. New will be ignored. Becase of <propose> strategy.",
+      );
+    } else if (
+      options.strategy === "replace" ||
+      /// this is the exactly strategy that will be used for all another inline or-like conditions
+      !prev ||
+      /// nothing to do with strategies
+      options.type !== typeof prev ||
+      /// for types mismatch between prev and new values we use default <replace> strategy
+      !["object", "array"].includes(options.type)
+      /// <merge*> strategies are not possible for primitives and <propose> variant was already eliminated
+    ) {
+      /// so <replace> means simply to use recently obtained <value>
+    } else {
+      if (options.strategy === "merge") {
+        value = Array.isArray(value)
+          ? [...prev, ...value]
+          : { ...prev, ...value };
+      } else if (options.strategy === "deep-merge") {
+        value = deep_merge(prev, value);
+      } else {
+        throw new Error(
+          "MAGIC_ERROR: not exhaustive condition pipe was used to check <strategy>",
+        );
+      }
+    }
 
     console.debug(`Set ${destination}.${prefix + k} = ${value}`);
 
     pm[destination].set(
-      prefix + k,
+      key,
       value,
-      is_string ? undefined : (last as { type: VarConvertType }).type,
+      options.type,
     );
   });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,8 +17,9 @@ declare global {
     string,
     MayBePath
   >;
-  type MayBePath = string[] | [...string[], { type: VarConvertType }];
-  type MayBeOptions = { type: VarConvertType };
+  type SetStrategy = "replace" | "propose" | "merge" | "deep-merge";
+  type MayBeOptions = { type?: VarConvertType; strategy?: SetStrategy };
+  type MayBePath = string[] | [...string[], MayBeOptions];
   type VarScopeName = "environment" | "collectionVariables" | "globals";
   type VarScope = Record<VarScopeName, {
     get: <T = string>(name: string) => T | null;


### PR DESCRIPTION
- **configure base build process**
  

- **rewrite initial version to ts-like project**
  

- **add guard feature**
  

- **refactor**
  

- **simplify json (auto res.json or res as j-data at once), refactor scripts in project**
  

- **fix aka build process**
  

- **incapsulate guard logic into magic**
  

- **fix res_codes**
  

- **alternative way to get res status code**
  

- **fix json from response as it is**
  

- **toy ci/cd refactor**
  

- **split logic into before and after query**
  So the same eval(pm.globals.get('magic'))
  can be used both in scripts
  after response and before query.
  

- **magic.name, magic.description**
  

- **auto stringify json-value during saving to pm vars**
  

- **use postman-collection types, use box solution for non-string vars**
  

- **update dependency of ts**
  

- **fix**
  

- **update deno tasks with more automated pr version**
  

- **update aka-docs comments in types**
  

- **start implement ctx (in single variable) feature**
  

- **from (string[] | [string[], options]) to (string[] | [...string[], options])**
  See:
  Simplify <set var> API for optional data type clarifications
  

- **feat: add <strategy> option for how to set variable See: Declare strategy how <set var> should behave is on this place already one was being**
  