### PR TITLE
dev

### DIFF
--- a/magic-postman-scripts.js
+++ b/magic-postman-scripts.js
@@ -29,9 +29,9 @@ function deep_merge(a, b) {
   return _b ?? _a;
 }
 
-function mapping(mapping2, source, destination, prefix = "") {
-  if (!mapping2) return;
-  Object.entries(mapping2).forEach(([k, mayBePath]) => {
+function mapping(mapping, source, destination, prefix = "") {
+  if (!mapping) return;
+  Object.entries(mapping).forEach(([k, mayBePath]) => {
     const last = mayBePath.pop();
     const path = mayBePath;
     if (!last) {
@@ -40,14 +40,23 @@ function mapping(mapping2, source, destination, prefix = "") {
     const options = {
       type: "string",
       strategy: "replace",
+      magic: null,
     };
     if (typeof last === "string") {
       path.push(last);
     } else {
       last.type && (options.type = last.type);
       last.strategy && (options.strategy = last.strategy);
+      last.magic && (options.magic = last.magic);
     }
     let value = path.reduce((acc, p) => acc[p], source);
+    if (options.magic) {
+      try {
+        value = eval(options.magic)(value);
+      } catch {
+        console.debug("PROBLEM: unable to make magic transformation for value");
+      }
+    }
     const key = prefix + k;
     const prev = pm[destination].get(key);
     if (prev && options.strategy === "propose") {

--- a/src/lib/mapping.ts
+++ b/src/lib/mapping.ts
@@ -17,6 +17,7 @@ export function mapping(
     const options: Required<MayBeOptions> = {
       type: "string",
       strategy: "replace",
+      magic: null,
     };
     if (typeof last === "string") {
       /// all items are strings - so it was only path
@@ -25,9 +26,18 @@ export function mapping(
       /// otherwise <last> is the type clarification
       last.type && (options.type = last.type);
       last.strategy && (options.strategy = last.strategy);
+      last.magic && (options.magic = last.magic);
     }
 
     let value: any = path.reduce((acc, p) => acc[p], source); /// move into object/array key/index by key/index
+
+    if (options.magic) {
+      try {
+        value = eval(options.magic)(value); /// since we expect function declaration - <eval> will be return the function and we pass <value> as argument to it
+      } catch {
+        console.debug("PROBLEM: unable to make magic transformation for value");
+      }
+    }
 
     const key = prefix + k;
     const prev = pm[destination].get<any>(key);

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,16 @@ declare global {
     MayBePath
   >;
   type SetStrategy = "replace" | "propose" | "merge" | "deep-merge";
-  type MayBeOptions = { type?: VarConvertType; strategy?: SetStrategy };
+  type MayBeOptions = {
+    type?: VarConvertType;
+    strategy?: SetStrategy;
+    /**
+     * @description
+     * If used - should be the string of js function with 1 parameter.
+     * The obtained by json-like path value will be used as argument.
+     */
+    magic?: string | null;
+  };
   type MayBePath = string[] | [...string[], MayBeOptions];
   type VarScopeName = "environment" | "collectionVariables" | "globals";
   type VarScope = Record<VarScopeName, {


### PR DESCRIPTION
- **configure base build process**
  

- **rewrite initial version to ts-like project**
  

- **add guard feature**
  

- **refactor**
  

- **simplify json (auto res.json or res as j-data at once), refactor scripts in project**
  

- **fix aka build process**
  

- **incapsulate guard logic into magic**
  

- **fix res_codes**
  

- **alternative way to get res status code**
  

- **fix json from response as it is**
  

- **toy ci/cd refactor**
  

- **split logic into before and after query**
  So the same eval(pm.globals.get('magic'))
  can be used both in scripts
  after response and before query.
  

- **magic.name, magic.description**
  

- **auto stringify json-value during saving to pm vars**
  

- **use postman-collection types, use box solution for non-string vars**
  

- **update dependency of ts**
  

- **fix**
  

- **update deno tasks with more automated pr version**
  

- **update aka-docs comments in types**
  

- **start implement ctx (in single variable) feature**
  

- **from (string[] | [string[], options]) to (string[] | [...string[], options])**
  See:
  Simplify <set var> API for optional data type clarifications
  

- **feat: add <strategy> option for how to set variable See: Declare strategy how <set var> should behave is on this place already one was being**
  

- **update magic script**
  

- **feat: possibility to define value transformation before saving See: Add possibility to convert value before setting**
  