### PR TITLE
dev

### DIFF
--- a/magic-postman-scripts.js
+++ b/magic-postman-scripts.js
@@ -54,14 +54,14 @@ function mapping(mapping, source, destination, prefix = "") {
       try {
         value = eval(options.magic)(value);
       } catch {
-        console.debug("PROBLEM: unable to make magic transformation for value");
+        console.info("PROBLEM: unable to make magic transformation for value");
       }
     }
     const key = prefix + k;
     const prev = pm[destination].get(key);
     if (prev && options.strategy === "propose") {
       value = prev;
-      console.debug(
+      console.info(
         "The old value will be used. New will be ignored. Becase of <propose> strategy.",
       );
     } else if (
@@ -83,7 +83,7 @@ function mapping(mapping, source, destination, prefix = "") {
         );
       }
     }
-    console.debug(`Set ${destination}.${prefix + k} = ${value}`);
+    console.info(`Set ${destination}.${prefix + k} = ${value}`);
     pm[destination].set(
       key,
       value,

--- a/magic-postman-scripts.js
+++ b/magic-postman-scripts.js
@@ -50,7 +50,9 @@ function mapping(mapping, source, destination, prefix = "") {
       last.magic && (options.magic = last.magic);
     }
     let value = path.reduce((acc, p) => acc[p], source);
+    console.log(options.magic);
     if (options.magic) {
+      console.log(value);
       try {
         value = eval(options.magic)(value);
       } catch {

--- a/src/lib/mapping.ts
+++ b/src/lib/mapping.ts
@@ -31,7 +31,9 @@ export function mapping(
 
     let value: any = path.reduce((acc, p) => acc[p], source); /// move into object/array key/index by key/index
 
+    console.log(options.magic);
     if (options.magic) {
+      console.log(value);
       try {
         value = eval(options.magic)(value); /// since we expect function declaration - <eval> will be return the function and we pass <value> as argument to it
       } catch {

--- a/src/lib/mapping.ts
+++ b/src/lib/mapping.ts
@@ -35,7 +35,7 @@ export function mapping(
       try {
         value = eval(options.magic)(value); /// since we expect function declaration - <eval> will be return the function and we pass <value> as argument to it
       } catch {
-        console.debug("PROBLEM: unable to make magic transformation for value");
+        console.info("PROBLEM: unable to make magic transformation for value");
       }
     }
 
@@ -45,7 +45,7 @@ export function mapping(
     if (prev && options.strategy === "propose") {
       /// for <propose> strategy we do not touch existed value and ignore new
       value = prev;
-      console.debug(
+      console.info(
         "The old value will be used. New will be ignored. Becase of <propose> strategy.",
       );
     } else if (
@@ -73,7 +73,7 @@ export function mapping(
       }
     }
 
-    console.debug(`Set ${destination}.${prefix + k} = ${value}`);
+    console.info(`Set ${destination}.${prefix + k} = ${value}`);
 
     pm[destination].set(
       key,


### PR DESCRIPTION
- **configure base build process**
  

- **rewrite initial version to ts-like project**
  

- **add guard feature**
  

- **refactor**
  

- **simplify json (auto res.json or res as j-data at once), refactor scripts in project**
  

- **fix aka build process**
  

- **incapsulate guard logic into magic**
  

- **fix res_codes**
  

- **alternative way to get res status code**
  

- **fix json from response as it is**
  

- **toy ci/cd refactor**
  

- **split logic into before and after query**
  So the same eval(pm.globals.get('magic'))
  can be used both in scripts
  after response and before query.
  

- **magic.name, magic.description**
  

- **auto stringify json-value during saving to pm vars**
  

- **use postman-collection types, use box solution for non-string vars**
  

- **update dependency of ts**
  

- **fix**
  

- **update deno tasks with more automated pr version**
  

- **update aka-docs comments in types**
  

- **start implement ctx (in single variable) feature**
  

- **from (string[] | [string[], options]) to (string[] | [...string[], options])**
  See:
  Simplify <set var> API for optional data type clarifications
  

- **feat: add <strategy> option for how to set variable See: Declare strategy how <set var> should behave is on this place already one was being**
  

- **update magic script**
  

- **feat: possibility to define value transformation before saving See: Add possibility to convert value before setting**
  

- **console.debug to info because it seems like in postman console there is no such level as <debug>**
  

- **debug/refactor**
  