### PR TITLE
dev

### DIFF
--- a/magic-postman-scripts.js
+++ b/magic-postman-scripts.js
@@ -49,12 +49,15 @@ function mapping(mapping, source, destination, prefix = "") {
       last.strategy && (options.strategy = last.strategy);
       last.magic && (options.magic = last.magic);
     }
+    console.log("options", options);
     let value = path.reduce((acc, p) => acc[p], source);
     console.log(options.magic);
     if (options.magic) {
       console.log(value);
       try {
-        value = eval(options.magic)(value);
+        const transform = eval(options.magic);
+        console.log(transform);
+        value = transform(value);
       } catch {
         console.info("PROBLEM: unable to make magic transformation for value");
       }

--- a/src/lib/mapping.ts
+++ b/src/lib/mapping.ts
@@ -28,6 +28,7 @@ export function mapping(
       last.strategy && (options.strategy = last.strategy);
       last.magic && (options.magic = last.magic);
     }
+    console.log("options", options);
 
     let value: any = path.reduce((acc, p) => acc[p], source); /// move into object/array key/index by key/index
 
@@ -35,7 +36,9 @@ export function mapping(
     if (options.magic) {
       console.log(value);
       try {
-        value = eval(options.magic)(value); /// since we expect function declaration - <eval> will be return the function and we pass <value> as argument to it
+        const transform = eval(options.magic);
+        console.log(transform);
+        value = transform(value); /// since we expect function declaration - <eval> will be return the function and we pass <value> as argument to it
       } catch {
         console.info("PROBLEM: unable to make magic transformation for value");
       }


### PR DESCRIPTION
- **configure base build process**
  

- **rewrite initial version to ts-like project**
  

- **add guard feature**
  

- **refactor**
  

- **simplify json (auto res.json or res as j-data at once), refactor scripts in project**
  

- **fix aka build process**
  

- **incapsulate guard logic into magic**
  

- **fix res_codes**
  

- **alternative way to get res status code**
  

- **fix json from response as it is**
  

- **toy ci/cd refactor**
  

- **split logic into before and after query**
  So the same eval(pm.globals.get('magic'))
  can be used both in scripts
  after response and before query.
  

- **magic.name, magic.description**
  

- **auto stringify json-value during saving to pm vars**
  

- **use postman-collection types, use box solution for non-string vars**
  

- **update dependency of ts**
  

- **fix**
  

- **update deno tasks with more automated pr version**
  

- **update aka-docs comments in types**
  

- **start implement ctx (in single variable) feature**
  

- **from (string[] | [string[], options]) to (string[] | [...string[], options])**
  See:
  Simplify <set var> API for optional data type clarifications
  

- **feat: add <strategy> option for how to set variable See: Declare strategy how <set var> should behave is on this place already one was being**
  

- **update magic script**
  

- **feat: possibility to define value transformation before saving See: Add possibility to convert value before setting**
  

- **console.debug to info because it seems like in postman console there is no such level as <debug>**
  

- **debug/refactor**
  

- **debug**
  