### PR TITLE
dev

### DIFF
--- a/magic-postman-scripts.js
+++ b/magic-postman-scripts.js
@@ -68,7 +68,8 @@ function mapping(mapping, source, destination, prefix = "") {
     } else if (
       options.strategy === "replace" || /// this is the exactly strategy that will be used for all another inline or-like conditions
       !prev || /// nothing to do with strategies
-      options.type !== typeof prev || /// for types mismatch between prev and new values we use default <replace> strategy
+      options.type !== typeof prev && /// for types mismatch between prev and new values we use default <replace> strategy
+        options.type === "array" && !Array.isArray(prev) ||
       !["object", "array"].includes(options.type)
     );
     else {

--- a/src/lib/mapping.ts
+++ b/src/lib/mapping.ts
@@ -55,8 +55,12 @@ export function mapping(
       /// this is the exactly strategy that will be used for all another inline or-like conditions
       !prev ||
       /// nothing to do with strategies
-      options.type !== typeof prev ||
-      /// for types mismatch between prev and new values we use default <replace> strategy
+      (
+        options.type !== typeof prev &&
+        /// for types mismatch between prev and new values we use default <replace> strategy
+        options.type === "array" && !Array.isArray(prev)
+        /// but because <array> is treated as <object> we should make this extra check
+      ) ||
       !["object", "array"].includes(options.type)
       /// <merge*> strategies are not possible for primitives and <propose> variant was already eliminated
     ) {


### PR DESCRIPTION
- **configure base build process**
  

- **rewrite initial version to ts-like project**
  

- **add guard feature**
  

- **refactor**
  

- **simplify json (auto res.json or res as j-data at once), refactor scripts in project**
  

- **fix aka build process**
  

- **incapsulate guard logic into magic**
  

- **fix res_codes**
  

- **alternative way to get res status code**
  

- **fix json from response as it is**
  

- **toy ci/cd refactor**
  

- **split logic into before and after query**
  So the same eval(pm.globals.get('magic'))
  can be used both in scripts
  after response and before query.
  

- **magic.name, magic.description**
  

- **auto stringify json-value during saving to pm vars**
  

- **use postman-collection types, use box solution for non-string vars**
  

- **update dependency of ts**
  

- **fix**
  

- **update deno tasks with more automated pr version**
  

- **update aka-docs comments in types**
  

- **start implement ctx (in single variable) feature**
  

- **from (string[] | [string[], options]) to (string[] | [...string[], options])**
  See:
  Simplify <set var> API for optional data type clarifications
  

- **feat: add <strategy> option for how to set variable See: Declare strategy how <set var> should behave is on this place already one was being**
  

- **update magic script**
  

- **feat: possibility to define value transformation before saving See: Add possibility to convert value before setting**
  

- **console.debug to info because it seems like in postman console there is no such level as <debug>**
  

- **debug/refactor**
  

- **debug**
  

- **debug**
  

- **rm logs**
  

- **refactor**
  

- **update magic script**
  

- **fix: array is object, so extra type check is needed**
  