### PR TITLE
dev

### DIFF
--- a/magic-postman-scripts.js
+++ b/magic-postman-scripts.js
@@ -16,17 +16,22 @@ function guard_before_query() {
   }
 }
 
-function deep_merge(a, b) {
-  const _a = a;
-  const _b = b;
-  if (Array.isArray(_a) && Array.isArray(_b)) return [..._a, ..._b];
-  if (_a && _b && typeof _a === "object" && typeof _b === "object") {
-    return Object.fromEntries(
-      (/* @__PURE__ */ new Set([...Object.keys(_a), ...Object.keys(_b)]))
-        .values(),
-    ).map((key) => [key, deep_merge(_a[key], _b[key])]);
-  }
-  return _b ?? _a;
+function deep_merge(...objects) {
+  const isObject = (obj) => obj && typeof obj === "object";
+  return objects.reduce((prev, obj) => {
+    Object.keys(obj).forEach((key) => {
+      const pVal = prev[key];
+      const oVal = obj[key];
+      if (Array.isArray(pVal) && Array.isArray(oVal)) {
+        prev[key] = pVal.concat(...oVal);
+      } else if (isObject(pVal) && isObject(oVal)) {
+        prev[key] = deep_merge(pVal, oVal);
+      } else {
+        prev[key] = oVal;
+      }
+    });
+    return prev;
+  }, {});
 }
 
 function mapping(mapping, source, destination, prefix = "") {

--- a/src/helpers/deep_merge.ts
+++ b/src/helpers/deep_merge.ts
@@ -1,11 +1,20 @@
-export function deep_merge<T>(a: T, b: T): T {
-  const _a: any = a;
-  const _b: any = b;
-  if (Array.isArray(_a) && Array.isArray(_b)) return [..._a, ..._b] as T;
-  if (_a && _b && typeof _a === "object" && typeof _b === "object") {
-    return Object.fromEntries(
-      new Set([...Object.keys(_a), ...Object.keys(_b)] as any[]).values(),
-    ).map((key: any) => [key, deep_merge(_a[key], _b[key])]) as T;
-  }
-  return _b ?? _a;
+export function deep_merge(...objects: any[]) {
+  const isObject = (obj: any) => obj && typeof obj === "object";
+
+  return objects.reduce((prev, obj) => {
+    Object.keys(obj).forEach((key) => {
+      const pVal = prev[key];
+      const oVal = obj[key];
+
+      if (Array.isArray(pVal) && Array.isArray(oVal)) {
+        prev[key] = pVal.concat(...oVal);
+      } else if (isObject(pVal) && isObject(oVal)) {
+        prev[key] = deep_merge(pVal, oVal);
+      } else {
+        prev[key] = oVal;
+      }
+    });
+
+    return prev;
+  }, {});
 }


### PR DESCRIPTION
- **configure base build process**
  

- **rewrite initial version to ts-like project**
  

- **add guard feature**
  

- **refactor**
  

- **simplify json (auto res.json or res as j-data at once), refactor scripts in project**
  

- **fix aka build process**
  

- **incapsulate guard logic into magic**
  

- **fix res_codes**
  

- **alternative way to get res status code**
  

- **fix json from response as it is**
  

- **toy ci/cd refactor**
  

- **split logic into before and after query**
  So the same eval(pm.globals.get('magic'))
  can be used both in scripts
  after response and before query.
  

- **magic.name, magic.description**
  

- **auto stringify json-value during saving to pm vars**
  

- **use postman-collection types, use box solution for non-string vars**
  

- **update dependency of ts**
  

- **fix**
  

- **update deno tasks with more automated pr version**
  

- **update aka-docs comments in types**
  

- **start implement ctx (in single variable) feature**
  

- **from (string[] | [string[], options]) to (string[] | [...string[], options])**
  See:
  Simplify <set var> API for optional data type clarifications
  

- **feat: add <strategy> option for how to set variable See: Declare strategy how <set var> should behave is on this place already one was being**
  

- **update magic script**
  

- **feat: possibility to define value transformation before saving See: Add possibility to convert value before setting**
  

- **console.debug to info because it seems like in postman console there is no such level as <debug>**
  

- **debug/refactor**
  

- **debug**
  

- **debug**
  

- **rm logs**
  

- **refactor**
  

- **update magic script**
  

- **fix: array is object, so extra type check is needed**
  

- **fix deep_merge function use https://stackoverflow.com/questions/27936772/how-to-deep-merge-instead-of-shallow-merge?page=1&tab=scoredesc#tab-top solution**
  